### PR TITLE
Add macOS menubar clipboard manager skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # PasteM
-macOS Clipboard Manager
+
+A minimal macOS menubar clipboard manager written in Swift/SwiftUI. This repository contains all source files needed to build the app. The `.xcodeproj` bundle is not included; follow the steps below to create one.
+
+## Project Setup
+
+1. Open **Xcode** and choose **File > New > Project**.
+2. Select **App** and click **Next**.
+3. Enter `PasteM` as the product name and ensure **Swift** and **SwiftUI** are selected.
+4. Save the project inside this repository so that the `Sources` directory replaces the generated `ContentView.swift` and others.
+5. Add the files from the `Sources/PasteM` directory to your Xcode target.
+
+### Permissions
+The app needs the following capabilities:
+- **App Sandbox** enabled.
+- **User Selected File** read/write for storing history.
+
+For launch at login, the project must include the **ServiceManagement** framework.
+
+### Code Signing
+Use your Apple Developer account to sign the app for running outside of Xcode. For personal use, a free developer account works.
+
+### Deployment
+1. Build the project with **Product > Archive**.
+2. Use the **Organizer** window to export the app or notarize it if distributing.
+
+## Usage
+Run the app from Xcode. A clipboard icon appears in the menubar. Click it to open the clipboard history. Items can be searched, copied again, or marked as favorites. Preferences allow changing the history limit and enabling launch at login.
+
+## Extending
+The code is heavily commented to explain the logic of each component. You can modify `ClipboardStore` to support additional data types or to integrate iCloud sync.

--- a/Sources/PasteM/AppDelegate.swift
+++ b/Sources/PasteM/AppDelegate.swift
@@ -1,0 +1,39 @@
+import Cocoa
+import SwiftUI
+
+/// Main application delegate responsible for managing the status bar item
+/// and injecting shared stores.
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem!
+    private var popover: NSPopover!
+    
+    /// Shared clipboard store accessible across the app.
+    let clipboardStore = ClipboardStore()
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Set up status bar item with icon
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = statusItem.button {
+            button.image = NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: "Clipboard")
+            button.action = #selector(togglePopover(_:))
+        }
+
+        // Configure SwiftUI view inside a popover
+        popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentSize = NSSize(width: 300, height: 400)
+        popover.contentViewController = NSHostingController(rootView: ClipboardView().environmentObject(clipboardStore))
+
+        // Start monitoring clipboard
+        clipboardStore.startMonitoring()
+    }
+
+    /// Toggles the popover when the menu bar icon is clicked
+    @objc func togglePopover(_ sender: AnyObject?) {
+        if popover.isShown {
+            popover.performClose(sender)
+        } else if let button = statusItem.button {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        }
+    }
+}

--- a/Sources/PasteM/ClipboardItem.swift
+++ b/Sources/PasteM/ClipboardItem.swift
@@ -1,0 +1,15 @@
+import Foundation
+import AppKit
+
+/// Represents a single clipboard entry. Supports text, images and URLs.
+struct ClipboardItem: Identifiable, Codable {
+    enum Content: Codable {
+        case text(String)
+        case image(Data) // PNG data
+        case url(URL)
+    }
+    let id: UUID
+    let date: Date
+    var isFavorite: Bool
+    var content: Content
+}

--- a/Sources/PasteM/ClipboardRow.swift
+++ b/Sources/PasteM/ClipboardRow.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Displays a single clipboard entry
+struct ClipboardRow: View {
+    let item: ClipboardItem
+
+    var body: some View {
+        HStack(alignment: .top) {
+            thumbnail
+            VStack(alignment: .leading) {
+                contentText
+                Text(item.date, style: .time)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Button(action: {
+                NSPasteboard.general.clearContents()
+                switch item.content {
+                case .text(let str):
+                    NSPasteboard.general.setString(str, forType: .string)
+                case .image(let data):
+                    if let img = NSImage(data: data) {
+                        NSPasteboard.general.writeObjects([img])
+                    }
+                case .url(let url):
+                    NSPasteboard.general.setString(url.absoluteString, forType: .string)
+                }
+            }) {
+                Image(systemName: "doc.on.doc")
+            }
+        }
+        .padding(4)
+        .background(item.isFavorite ? Color.yellow.opacity(0.2) : Color.clear)
+        .cornerRadius(4)
+    }
+
+    /// Generates a preview thumbnail based on content type
+    private var thumbnail: some View {
+        Group {
+            switch item.content {
+            case .text:
+                Image(systemName: item.isFavorite ? "star.fill" : "doc.text")
+                    .foregroundColor(item.isFavorite ? .yellow : .accentColor)
+            case .image(let data):
+                if let img = NSImage(data: data) {
+                    Image(nsImage: img)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                } else {
+                    Image(systemName: "photo")
+                }
+            case .url:
+                Image(systemName: "link")
+            }
+        }
+        .frame(width: 30, height: 30)
+    }
+
+    /// Text representation of the content
+    private var contentText: some View {
+        Group {
+            switch item.content {
+            case .text(let str):
+                Text(str).lineLimit(2)
+            case .image:
+                Text("Image")
+            case .url(let url):
+                Text(url.absoluteString)
+            }
+        }
+    }
+}

--- a/Sources/PasteM/ClipboardStore.swift
+++ b/Sources/PasteM/ClipboardStore.swift
@@ -1,0 +1,99 @@
+import Foundation
+import AppKit
+
+/// Monitors the system pasteboard and stores recent clipboard items.
+final class ClipboardStore: ObservableObject {
+    /// Maximum number of recent items to keep
+    @Published var limit: Int = 20
+    /// All clipboard items sorted by date (most recent first)
+    @Published private(set) var items: [ClipboardItem] = []
+
+    /// Timer for polling the pasteboard
+    private var timer: Timer?
+    private var changeCount: Int = NSPasteboard.general.changeCount
+
+    /// Path where items are persisted
+    private var archiveURL: URL {
+        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = supportDir.appendingPathComponent("PasteM", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("history.json")
+    }
+
+    /// Start monitoring the clipboard
+    func startMonitoring() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.checkClipboard()
+        }
+        loadFromDisk()
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    /// Poll the clipboard for changes
+    private func checkClipboard() {
+        let pb = NSPasteboard.general
+        guard pb.changeCount != changeCount else { return }
+        changeCount = pb.changeCount
+
+        if let newItem = readPasteboard(pb) {
+            DispatchQueue.main.async {
+                self.prepend(newItem)
+            }
+        }
+    }
+
+    /// Read pasteboard contents as ClipboardItem
+    private func readPasteboard(_ pb: NSPasteboard) -> ClipboardItem? {
+        if let str = pb.string(forType: .string) {
+            return ClipboardItem(id: UUID(), date: Date(), isFavorite: false, content: .text(str))
+        }
+        if let data = pb.data(forType: .png) {
+            return ClipboardItem(id: UUID(), date: Date(), isFavorite: false, content: .image(data))
+        }
+        if let urlStr = pb.string(forType: .fileURL), let url = URL(string: urlStr) {
+            return ClipboardItem(id: UUID(), date: Date(), isFavorite: false, content: .url(url))
+        }
+        return nil
+    }
+
+    /// Insert item and trim history
+    private func prepend(_ item: ClipboardItem) {
+        items.insert(item, at: 0)
+        if items.count > limit {
+            items.removeLast(items.count - limit)
+        }
+        saveToDisk()
+    }
+
+    /// Toggle favorite flag for item
+    func toggleFavorite(_ item: ClipboardItem) {
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+            items[index].isFavorite.toggle()
+            saveToDisk()
+        }
+    }
+
+    /// Persist items to disk
+    private func saveToDisk() {
+        do {
+            let data = try JSONEncoder().encode(items)
+            try data.write(to: archiveURL)
+        } catch {
+            NSLog("Failed to save history: \(error)")
+        }
+    }
+
+    /// Load saved history
+    private func loadFromDisk() {
+        do {
+            let data = try Data(contentsOf: archiveURL)
+            items = try JSONDecoder().decode([ClipboardItem].self, from: data)
+        } catch {
+            // ignore if no history yet
+            items = []
+        }
+    }
+}

--- a/Sources/PasteM/ClipboardView.swift
+++ b/Sources/PasteM/ClipboardView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// Main view displayed inside the status bar popover
+struct ClipboardView: View {
+    @EnvironmentObject var store: ClipboardStore
+    @State private var searchText = ""
+
+    var filteredItems: [ClipboardItem] {
+        if searchText.isEmpty { return store.items }
+        return store.items.filter { item in
+            switch item.content {
+            case .text(let str):
+                return str.lowercased().contains(searchText.lowercased())
+            case .url(let url):
+                return url.absoluteString.lowercased().contains(searchText.lowercased())
+            case .image:
+                return false
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            SearchField(text: $searchText)
+                .padding([.top, .leading, .trailing])
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(filteredItems) { item in
+                        ClipboardRow(item: item)
+                            .contextMenu {
+                                Button(item.isFavorite ? "Unfavorite" : "Favorite") {
+                                    store.toggleFavorite(item)
+                                }
+                            }
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+        .frame(minWidth: 280, minHeight: 300)
+    }
+}
+
+/// Search field wrapper to support older macOS versions
+struct SearchField: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let field = NSSearchField(string: text)
+        field.delegate = context.coordinator
+        return field
+    }
+
+    func updateNSView(_ nsView: NSSearchField, context: Context) {
+        nsView.stringValue = text
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, NSSearchFieldDelegate {
+        var parent: SearchField
+        init(_ parent: SearchField) { self.parent = parent }
+        func controlTextDidChange(_ obj: Notification) {
+            if let field = obj.object as? NSSearchField {
+                parent.text = field.stringValue
+            }
+        }
+    }
+}

--- a/Sources/PasteM/PasteMApp.swift
+++ b/Sources/PasteM/PasteMApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import AppKit
+
+@main
+struct PasteMApp: App {
+    // The AppDelegate will handle status bar and menu setup
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        // Settings scene for preferences
+        Settings {
+            PreferencesView()
+        }
+    }
+}

--- a/Sources/PasteM/PreferencesView.swift
+++ b/Sources/PasteM/PreferencesView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+/// Preferences window for setting history limit and launch on login
+struct PreferencesView: View {
+    @EnvironmentObject var store: ClipboardStore
+    @AppStorage("launchAtLogin") private var launchAtLogin: Bool = false
+
+    var body: some View {
+        Form {
+            Stepper(value: $store.limit, in: 5...100, step: 1) {
+                Text("History Limit: \(store.limit)")
+            }
+            Toggle("Launch at Login", isOn: $launchAtLogin)
+                .onChange(of: launchAtLogin) { value in
+                    StartupManager.setLaunchAtLogin(enabled: value)
+                }
+        }
+        .padding()
+        .frame(width: 300)
+    }
+}

--- a/Sources/PasteM/StartupManager.swift
+++ b/Sources/PasteM/StartupManager.swift
@@ -1,0 +1,8 @@
+import ServiceManagement
+
+/// Manages enabling or disabling launch at login for the app
+enum StartupManager {
+    static func setLaunchAtLogin(enabled: Bool) {
+        SMLoginItemSetEnabled(Bundle.main.bundleIdentifier! as CFString, enabled)
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftUI menubar clipboard manager app source
- include clipboard monitoring and persistence
- add preferences for history limit and launch at login
- document setup instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eb1bd8cbc832abe8cb35196a0ac8d